### PR TITLE
Filter pages based on catalog parent-id and tags

### DIFF
--- a/src/helpers/get-page-cards.js
+++ b/src/helpers/get-page-cards.js
@@ -8,6 +8,12 @@ module.exports = (parentPage, tag, withinParentModule = true, { data: { root } }
       (withinParentModule && src.module !== parentPage.module) ||
       src.version !== parentPage.componentVersion.version) return
     const pageTags = asciidoc.attributes['page-tags']
+    if (pageTags && pageTags.split(',').map((tag) => tag.trim()).includes('catalog') &&
+      parentPage.attributes.tags && asciidoc.attributes['parent-catalogs'] &&
+      asciidoc.attributes['parent-catalogs'].split(',').map((parentCat) => parentCat.trim()).every((parentCat) =>
+        !parentPage.attributes.tags.split(',').map((parentTag) => parentTag.trim()).includes(parentCat)
+      )
+    ) return
     return pageTags && pageTags.split(',').map((v) => v.trim()).includes(tag)
   }).sort((a, b) => (a.title || '').localeCompare((b.title || '')))
   if (pages && pages.length > 0) {


### PR DESCRIPTION
- Closes #79 

Added a filter to _helpers/get-page-cards.js_ that:
 - Checks if the `catalog` tag is present in a page.
 - Gets the identifiers of the parents pages by looking at the `parent-catalogs` attribute. 
 - Gets the actual identifier of the parent page, located as `tags` in the actual parent page attributes
 - If the parent page contains any of the tags present in the `parent-catalogs`, it will be nested inside that module. 

[ Example usage]
The work still uses the `toolboxes` page layout, but searches for the `catalog` tag to not interfere with existing work. 

The base of the catalog system should have the following attributes, assuming I want to set the id of the page to `base-id`: 
```
:page-layout: toolboxes
:page-tags: catalog, base-id
``` 

Then for any direct child of the `base-id` page :  
```
:page-layout: toolboxes
:page-tags: catalog, toolbox, my-page-1-id
:parent-catalogs: base-id
``` 

If I want to create a card that appears both on the `base-id` and the `my-page-1-id` pages I can do: 
```
:page-layout: default
:page-tags: catalog, toolbox, my-leaf-page
:parent-catalogs: base-id, my-page-1-id

= My Leaf page content... 
``` 


[NOTES]
- the page layout of all catalog pages that have children should be `toolboxes`
- All pages inside the catalog must have the `catalog` tag and the `toolbox` tag (for cards to appear) 
- A page can have multiple parents. 
- The page-layout of the leaf pages is not important 

