### PR TITLE
resolves : 88 support having additional elements on catalog layout body

### DIFF
--- a/docs/modules/ROOT/pages/catalogExample/catalog.adoc
+++ b/docs/modules/ROOT/pages/catalogExample/catalog.adoc
@@ -1,7 +1,10 @@
-:page-layout: toolboxes
-:page-tags: toolbox, catalog, catalog-base
+:page-layout: dashboard
+:page-tags: catalog, catalog-base
 :parent-catalogs: page-layouts
 :description: Example of the catalog page layout.
 :page-illustration: ROOT:grid.png
 
 = Catalog
+
+== Description
+This is the base page of the catalog. It is identified by the `catalog-base` tag, and also contains the `catalog` tag, making it available to have child items.

--- a/docs/modules/ROOT/pages/catalogExample/itemA.adoc
+++ b/docs/modules/ROOT/pages/catalogExample/itemA.adoc
@@ -1,6 +1,9 @@
 = Item A
-:page-layout: toolboxes
-:page-tags: toolbox, catalog, itemA
+:page-layout: dashboard
+:page-tags: catalog, itemA
 :parent-catalogs: catalog-base
 :description: Item containing 2 subitems.
 :page-illustration: ROOT:A.png
+
+== Description
+This page is a catalog item, children of the root item, containing 2 subitems.

--- a/docs/modules/ROOT/pages/catalogExample/itemB.adoc
+++ b/docs/modules/ROOT/pages/catalogExample/itemB.adoc
@@ -1,6 +1,9 @@
 = Item B
-:page-layout: toolboxes
-:page-tags: toolbox, catalog, itemB
+:page-layout: dashboard
+:page-tags: catalog, itemB
 :parent-catalogs: catalog-base
 :description: Item containing 1 shared subitem.
 :page-illustration: ROOT:B.png
+
+== Description
+This page is a catalog item, containing Item C as children, which is shared with the catalog base.

--- a/docs/modules/ROOT/pages/catalogExample/itemC.adoc
+++ b/docs/modules/ROOT/pages/catalogExample/itemC.adoc
@@ -1,5 +1,5 @@
 = Item C
-:page-tags: toolbox, catalog, itemC
+:page-tags: catalog, itemC
 :parent-catalogs: catalog-base, itemB
 :description: Leaf item.
 :page-illustration: ROOT:C.png
@@ -13,14 +13,14 @@ To replicate this page structure:
 - Base page
 [asciidoc]
 ----
-:page-layout: toolboxes
+:page-layout: dashboard
 :page-tags: catalog, catalog-base
 ----
 
 - Item B
 [asciidoc]
 ----
-:page-layout: toolboxes
+:page-layout: dashboard
 :page-tags: catalog, itemB
 :parent-catalogs: catalog-base
 ----

--- a/docs/modules/ROOT/pages/catalogExample/subitemA1.adoc
+++ b/docs/modules/ROOT/pages/catalogExample/subitemA1.adoc
@@ -1,5 +1,5 @@
 = Subitem A-1
-:page-tags: toolbox, catalog, subitemA-1
+:page-tags: catalog, subitemA-1
 :parent-catalogs: itemA
 :page-illustration: ROOT:A-1.png
 
@@ -12,14 +12,14 @@ To replicate this page structure:
 - Base page
 [asciidoc]
 ----
-:page-layout: toolboxes
+:page-layout: dashboard
 :page-tags: catalog, catalog-base
 ----
 
 - Item A
 [asciidoc]
 ----
-:page-layout: toolboxes
+:page-layout: dashboard
 :page-tags: catalog, itemA
 :parent-catalogs: catalog-base
 ----

--- a/docs/modules/ROOT/pages/catalogExample/subitemA2.adoc
+++ b/docs/modules/ROOT/pages/catalogExample/subitemA2.adoc
@@ -1,5 +1,5 @@
 = Subitem A-2
-:page-tags: toolbox, catalog, subitemA-2
+:page-tags: catalog, subitemA-2
 :parent-catalogs: itemA
 :page-illustration: ROOT:A-2.png
 
@@ -12,14 +12,14 @@ To replicate this page structure:
 - Base page
 [asciidoc]
 ----
-:page-layout: toolboxes
+:page-layout: dashboard
 :page-tags: catalog, catalog-base
 ----
 
 - Item A
 [asciidoc]
 ----
-:page-layout: toolboxes
+:page-layout: dashboard
 :page-tags: catalog, itemA
 :parent-catalogs: catalog-base
 ----

--- a/docs/modules/ROOT/pages/page-layouts.adoc
+++ b/docs/modules/ROOT/pages/page-layouts.adoc
@@ -1,4 +1,4 @@
 = Page Layouts
 :navtitle: Page Layouts
-:page-layout: toolboxes
-:page-tags: catalog, page-layouts
+:page-layout: dashboard
+:page-tags: page-layouts

--- a/src/css/case-study.css
+++ b/src/css/case-study.css
@@ -1,6 +1,7 @@
 .docs-case-study .cases,
 .docs-case-study .benchmarks,
 .docs-case-study .toolboxes,
+.docs-case-study .dashboard,
 .docs-case-study .manuals {
   display: flex;
   flex-wrap: wrap;
@@ -13,6 +14,7 @@
 .docs-case-study .cases .case,
 .docs-case-study .benchmarks .benchmark,
 .docs-case-study .toolboxes .toolbox,
+.docs-case-study .dashboard .catalog,
 .docs-case-study .manuals .manual {
   display: flex;
   flex: 1 calc(33.33% - 5em);
@@ -24,6 +26,7 @@
   .docs-case-study .cases .case,
   .docs-case-study .benchmarks .benchmark,
   .docs-case-study .toolboxes .toolbox,
+  .docs-case-study .dashboard .catalog,
   .docs-case-study .manuals .manual {
     flex: 1 250px;
   }
@@ -34,6 +37,7 @@
   .docs-case-study .cases .case,
   .docs-case-study .benchmarks .benchmark,
   .docs-case-study .toolboxes .toolbox,
+  .docs-case-study .dashboard .catalog,
   .docs-case-study .manuals .manual {
     min-width: 250px;
   }

--- a/src/layouts/dashboard.hbs
+++ b/src/layouts/dashboard.hbs
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  {{> head defaultPageTitle='Untitled'}}
+</head>
+<body class="article docs-case-study{{#with (or page.attributes.role page.role)}} {{{this}}}{{/with}}">
+{{> header}}
+
+<div class="body">
+  {{> nav componentOrder=page.attributes.component-order}}
+  <main class="article">
+    <div class="toolbar" role="navigation">
+      {{> nav-toggle}}
+      {{#with site.homeUrl}}
+        <a href="{{{relativize this}}}" class="home-link{{#if @root.page.home}} is-current{{/if}}"></a>
+      {{/with}}
+      {{> breadcrumbs}}
+    </div>
+
+    <div class="content">
+      <article class="doc">
+        {{#with @root.page.title}}
+          <h1 class="page">{{{this}}}</h1>
+        {{/with}}
+        {{#with (get-page-cards @root.page 'catalog' false)}}
+          {{#if this.length}}
+          <div class="dashboard">
+            {{#each this}}
+              <div class="catalog">{{> page-card this}}</div>
+            {{/each}}
+          </div>
+          {{/if}}
+        {{/with}}
+        {{{page.contents}}}
+      </article>
+    </div>
+  </main>
+</div>
+
+{{> footer}}
+</body>
+</html>


### PR DESCRIPTION
- Closes #88 

Toolbox and catalog page layouts have been separated.
A new template for dashboard pages has been added, allowing users to enter additional content on a catalog page. 